### PR TITLE
Adding additional file format argument to requests for adding tutorial files

### DIFF
--- a/projects/web-mev/src/app/features/tutorial/tutorial.component.html
+++ b/projects/web-mev/src/app/features/tutorial/tutorial.component.html
@@ -26,7 +26,7 @@
               <th mat-header-cell *matHeaderCellDef>  </th>
               <td mat-cell *matCellDef="let element">
                 <button mat-raised-button color="accent" 
-                  (click)="addFile(element.bucket_path, element.resource_type)">
+                  (click)="addFile(element.bucket_path, element.resource_type, element.file_format)">
                   <mat-icon aria-label="Add file to account">add</mat-icon>
                   Add to my account
                 </button>

--- a/projects/web-mev/src/app/features/tutorial/tutorial.component.ts
+++ b/projects/web-mev/src/app/features/tutorial/tutorial.component.ts
@@ -27,19 +27,22 @@ export class TutorialComponent implements OnInit {
       name: 'Example count matrix',
       direct_url: 'https://storage.googleapis.com/mev-example-data/hbr_and_uhr_counts.tsv',
       bucket_path: 'gs://mev-example-data/hbr_and_uhr_counts.tsv',
-      resource_type: 'RNASEQ_COUNT_MTX'
+      resource_type: 'RNASEQ_COUNT_MTX',
+      file_format: 'TSV'
     },
     {
       name: 'Example annotations',
       direct_url: 'https://storage.googleapis.com/mev-example-data/hbr_and_uhr_annotations.csv',
       bucket_path: 'gs://mev-example-data/hbr_and_uhr_annotations.csv',
-      resource_type: 'ANN'
+      resource_type: 'ANN',
+      file_format: 'CSV'
     },
     {
       name: 'Example single-cell dataset (counts only)',
       direct_url: 'https://storage.googleapis.com/mev-example-data/sctk_1k.csv',
       bucket_path: 'gs://mev-example-data/sctk_1k.csv',
-      resource_type: 'RNASEQ_COUNT_MTX'
+      resource_type: 'RNASEQ_COUNT_MTX',
+      file_format: 'CSV'
     }
   ];
   displayedColumns: string[];
@@ -59,11 +62,12 @@ export class TutorialComponent implements OnInit {
     }
   }
 
-  addFile(bucketPath: string, resourceType: string){
+  addFile(bucketPath: string, resourceType: string, file_format: string){
     this.tutorialService.addTutorialFile(
       {
         bucket_path: bucketPath,
-        resource_type: resourceType
+        resource_type: resourceType,
+        file_format: file_format
       }
     ).subscribe(
       x=>{


### PR DESCRIPTION
Need to include the `file_format` as part of the POST request payload.